### PR TITLE
build: Drop support for React 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,14 +92,8 @@ jobs:
       - attach_workspace:
           at: ~/repo
       - run_tests:
-          react_version: "^15"
-          immutable_version: "^3"
-      - run_tests:
           react_version: "^16"
           immutable_version: "^3"
-      - run_tests:
-          react_version: "^15"
-          immutable_version: "^4.0.0-rc.1"
       - run_tests:
           react_version: "^16"
           immutable_version: "^4.0.0-rc.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.1.0",
     "enzyme": "^3.7.0",
-    "enzyme-adapter-react-15": "^1.2.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^6.0.0",
@@ -53,11 +52,11 @@
   },
   "peerDependencies": {
     "immutable": ">=3.0.0",
-    "react": ">=15.0.0",
-    "react-dom": ">=15.0.0"
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/tests/setupTestFramework.js",
+    "setupFilesAfterEnv": ["<rootDir>/tests/setupTestFramework.js"],
     "collectCoverageFrom": [
       "src/**/*.js"
     ]

--- a/tests/setupTestFramework.js
+++ b/tests/setupTestFramework.js
@@ -1,10 +1,5 @@
 import enzyme from 'enzyme'
-import React from 'react'
 
-const [reactMajorVersion] = React.version.split('.')
-
-const Adapter = require(reactMajorVersion === '15'
-    ? 'enzyme-adapter-react-15'
-    : 'enzyme-adapter-react-16')
+const Adapter = require('enzyme-adapter-react-16')
 
 enzyme.configure({ adapter: new Adapter() })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,17 +1657,6 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-enzyme-adapter-react-15@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.2.0.tgz#f05c838e7810f96fb0cfc3aa09ff6c305c7ada6d"
-  integrity sha512-yxghXadauBtUFTA6P2FK/5E6mOVsCqafW5biqP647pSvX05HDTjr5fe7fcfWJ0e0e4/G6redqn+eJ0IC7Tq//A==
-  dependencies:
-    enzyme-adapter-utils "^1.9.0"
-    object.assign "^4.1.0"
-    object.values "^1.0.4"
-    prop-types "^15.6.2"
-    react-is "^16.6.1"
-
 enzyme-adapter-react-16@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.0.tgz#90344395a89624edbe7f0e443bc19fef62bf1f9f"


### PR DESCRIPTION
## Description

Removes everything to do with React 15. I've removed the matrix builds for React 15 from the CircleCI config, but left the support for matrix builds for when React 17 is published.

This is in preparation for #76, which uses React.forwardRef, which was only added in [React 16.3](https://github.com/facebook/react/blob/master/CHANGELOG.md#1630-march-29-2018). Peer dependencies have been updated accordingly.

That PR will be a BREAKING CHANGE, bumping this package to version 2.0.0. For anyone still on React 15, they'll still be able to use version ^1.0.0.
