### PR TITLE
test: Add test for forwarding function refs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-    "presets": ["@babel/preset-react", "@babel/preset-env"]
+    "presets": ["@babel/preset-react", "@babel/preset-env"],
+    "plugins": [
+        ["transform-react-remove-prop-types", { "removeImport": true }]
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "all-contributors-cli": "^6.9.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^6.3.0",
@@ -47,6 +48,7 @@
     "immutable": "^4.0.0-rc.12",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",
+    "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,12 @@ const withImmutablePropsToJS = WrappedComponent => {
     Wrapper.propTypes = {
         forwardedRef: PropTypes.oneOfType([
             PropTypes.func,
-            PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-        ]).isRequired,
+            PropTypes.shape({ current: PropTypes.node }),
+        ]),
+    }
+
+    Wrapper.defaultProps = {
+        forwardedRef: null,
     }
 
     const WrapperWithForwardedRef = React.forwardRef((props, ref) => (

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -128,4 +128,19 @@ describe('withImmutablePropsToJS', () => {
         )
         expect(myRef.current.innerHTML).toBe('some content')
     })
+
+    it('forwards function refs', () => {
+        let element
+        const myRef = ref => (element = ref)
+        const MyComponent = React.forwardRef((props, ref) => (
+            <div ref={ref}>some content</div>
+        ))
+        const WithImmutable = withImmutablePropsToJS(MyComponent)
+        mount(
+            <div>
+                <WithImmutable ref={myRef} />
+            </div>,
+        )
+        expect(element.innerHTML).toBe('some content')
+    })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,6 +1483,11 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
 babel-preset-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"


### PR DESCRIPTION
## Description

Added an additional test for forwarding refs.

Also fixed a prop type warning that showed up after #76 was merged, and added prop-types as a dev dependency while stripping them in the production build (it doesn't seem worth shipping prop-types as a direct dependency).
