### PR TITLE
build: Only remove prop-types when building a release

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,10 @@
 {
     "presets": ["@babel/preset-react", "@babel/preset-env"],
-    "plugins": [
-        ["transform-react-remove-prop-types", { "removeImport": true }]
-    ]
+    "env": {
+        "production": {
+            "plugins": [
+                ["transform-react-remove-prop-types", { "removeImport": true }]
+            ]
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest",
     "lint": "eslint . --max-warnings 0",
     "fix": "eslint --fix .",
-    "build": "babel src -d lib --copy-files",
+    "build": "NODE_ENV=production babel src -d lib --copy-files",
     "contrib:add": "all-contributors add",
     "contrib:generate": "all-contributors generate",
     "contrib:check": "all-contributors check",


### PR DESCRIPTION
## Description

This is so we still get prop type warnings in tests.