### PR TITLE
Expose WrappedComponent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ const withImmutablePropsToJS = WrappedComponent => {
     WrapperWithForwardedRef.displayName = `withImmutablePropsToJS(${getDisplayName(
         WrappedComponent,
     )})`
+    WrapperWithForwardedRef.WrappedComponent = WrappedComponent
 
     hoistNonReactStatics(WrapperWithForwardedRef, WrappedComponent)
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -143,4 +143,10 @@ describe('withImmutablePropsToJS', () => {
         )
         expect(element.innerHTML).toBe('some content')
     })
+
+    it('exposes the wrapped component', () => {
+        const MyComponent = () => <div />
+        const WithImmutable = withImmutablePropsToJS(MyComponent)
+        expect(WithImmutable.WrappedComponent).toBe(MyComponent)
+    })
 })


### PR DESCRIPTION
## Description

Expose the wrapped component as a property on the enhanced version. Similar to how `react-redux` exposes the underlying component in its `connect` HOC, this helps with finding the component in unit tests.

## Checklist

- [x] I've added new tests for any features added
- [ ] I've added regression tests for any bugs fixed
